### PR TITLE
Show block and estate information for a postcode

### DIFF
--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -2,6 +2,10 @@ class PropertiesController < ApplicationController
   def index
     if params[:post_code]
       @properties = AddressFinder.new.find(params[:post_code])
+      if @properties.present?
+        @block = Block.find_by_dwelling(property_reference: @properties.first.property_reference)
+        @estate = Estate.find_by_dwelling(property_reference: @properties.first.property_reference)
+      end
     end
   end
 end

--- a/app/models/block.rb
+++ b/app/models/block.rb
@@ -1,0 +1,15 @@
+class Block
+  include ActiveModel::Model
+
+  attr_accessor :propertyReference, :postcode, :address, :managerName,
+                :managerPhone, :managerEmail, :floors, :entranceDoors, :lifts,
+                :heating
+
+  def self.find_by_dwelling(dwelling_reference)
+    new_from_json(HackneyApi.new.get_block_for_dwelling(dwelling_reference))
+  end
+
+  def self.new_from_json(json)
+    new(json)
+  end
+end

--- a/app/models/estate.rb
+++ b/app/models/estate.rb
@@ -1,0 +1,14 @@
+class Estate
+  include ActiveModel::Model
+
+  attr_accessor :propertyReference, :postcode, :address, :managerName,
+                :managerPhone, :managerEmail
+
+  def self.find_by_dwelling(dwelling_reference)
+    new_from_json(HackneyApi.new.get_estate_for_dwelling(dwelling_reference))
+  end
+
+  def self.new_from_json(json)
+    new(json)
+  end
+end

--- a/app/queries/hackney_api.rb
+++ b/app/queries/hackney_api.rb
@@ -14,6 +14,14 @@ class HackneyApi
     @json_api.get('hackneyrepairs/v1/properties/' + property_reference)
   end
 
+  def get_estate_for_dwelling(property_reference:)
+    @json_api.get('hackneyrepairs/v1/properties/' + property_reference + '/estate')
+  end
+
+  def get_block_for_dwelling(property_reference:)
+    @json_api.get('hackneyrepairs/v1/properties/' + property_reference + '/block')
+  end
+
   def create_repair(repair_params)
     @json_api.post('hackneyrepairs/v1/repairs', repair_params)
   end

--- a/app/views/properties/index.html.haml
+++ b/app/views/properties/index.html.haml
@@ -13,3 +13,22 @@
       = link_to property.address, property_path(property.property_reference)
   - else
     %p No properties found
+
+- if defined?(@properties) && @properties.present?
+  %h2 Block information
+
+  = @block.address
+  = @block.managerName
+  = @block.managerEmail
+  = @block.managerPhone
+  = @block.floors
+  = @block.entranceDoors
+  = @block.lifts
+  = @block.heating
+
+  %h2 Estate information
+
+  = @estate.address
+  = @estate.managerName
+  = @estate.managerEmail
+  = @estate.managerPhone

--- a/spec/features/finding_and_viewing_a_property_spec.rb
+++ b/spec/features/finding_and_viewing_a_property_spec.rb
@@ -3,10 +3,16 @@ require 'rails_helper'
 RSpec.feature 'Admin can find a property' do
   scenario 'with correct postcode' do
     stub_property_search
+    stub_block_for_property
+    stub_estate_for_property
     visit '/properties/'
     fill_in 'Find address by postcode', with: 'E5 8TE'
     click_on 'Find'
     expect(page).to have_content "1 Estate House"
+    expect(page).to have_content "Hackney Block"
+    expect(page).to have_content "Bob Smith"
+    expect(page).to have_content "Hackney Estate"
+    expect(page).to have_content "Jane Smith"
   end
 
   scenario 'with incorrect postcode' do

--- a/spec/support/rcc_stubs.rb
+++ b/spec/support/rcc_stubs.rb
@@ -17,4 +17,40 @@ module RCCStubs
       headers: {},
     )
   end
+
+  def stub_block_for_property
+    stub_request(:get, "http://localhost:3000/hackneyrepairs/v1/properties/000001/block").
+    to_return(
+      status: 200,
+      body: {
+        address: "Hackney Block",
+        postcode:"E58TE",
+        propertyReference:"B00001",
+        managerName:"Bob Smith",
+        managerEmail:"test@test.com",
+        managerPhone:"07777777777",
+        floors:2,
+        entranceDoors:1,
+        lifts:1,
+        heating:"Mixed",
+      }.to_json,
+      headers: {},
+    )
+  end
+
+  def stub_estate_for_property
+    stub_request(:get, "http://localhost:3000/hackneyrepairs/v1/properties/000001/estate").
+    to_return(
+      status: 200,
+      body: {
+        address: "Hackney Estate",
+        postcode:"E58TE",
+        propertyReference:"B00001",
+        managerName:"Jane Smith",
+        managerEmail:"janes@test.com",
+        managerPhone:"07777777778",
+      }.to_json,
+      headers: {},
+    )
+  end
 end


### PR DESCRIPTION
Uses the new endpoints in mock-hackney-api (https://github.com/LBHackney-IT/mock_hackney_api/commit/f09cacfed21cb99ac731ddbb903aefbb7b794b6e) to display estate and block information on the post code search page.