### PR TITLE
Styled search result list and block/estate sidebar

### DIFF
--- a/app/assets/stylesheets/_main_rcc.scss
+++ b/app/assets/stylesheets/_main_rcc.scss
@@ -21,11 +21,31 @@
   p.title {
     margin-bottom: 0;
   }
-
-  .list-item {
-    display: block;
-  }
 }
+
+/*
+ * Typography classes
+ * Current hack until this is resolved https://github.com/zurb/foundation-sites/issues/9483
+ */
+
+  .h4 {
+    $header-styles-h4: (
+      small: (
+        'h4': ('font-size': 18),
+      ),
+      medium: (
+        'h4': ('font-size': 25),
+      ),
+    );
+  }
+
+/*
+ * List styles
+ */
+
+ .list-item {
+   display: block;
+ }
 
 .list-group {
   list-style: none;

--- a/app/assets/stylesheets/_main_rcc.scss
+++ b/app/assets/stylesheets/_main_rcc.scss
@@ -1,0 +1,51 @@
+ @import "settings";
+/*
+ * Global styles
+ */
+
+.main {
+  padding-top: 2em;
+}
+
+.side-nav {
+  border-right: 1px solid $medium-gray;
+  height: 100vh;
+  background-color: $light-gray;
+}
+
+.sidebar {
+  border-left: 1px solid $medium-gray;
+  height: 100vh;
+  background-color: $white;
+
+  p.title {
+    margin-bottom: 0;
+  }
+
+  .list-item {
+    display: block;
+  }
+}
+
+.list-group {
+  list-style: none;
+  margin-left: 0;
+
+  .list-group-item {
+    display: block;
+    position: relative;
+    cursor: pointer;
+    margin-bottom: -1px;
+    border: 1px solid $light-gray;
+    padding: $global-padding/2 0 $global-padding/2 $global-padding;
+
+    &:hover {
+      background-color: $light-gray;
+    }
+
+    a {
+      display: block;
+      width: 100%;
+    }
+  }
+}

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -866,4 +866,3 @@ $grid-padding-gutters: $grid-margin-gutters;
 $grid-container-padding: $grid-padding-gutters;
 $grid-container-max: $global-width;
 $xy-block-grid-max: 8;
-

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,4 +15,5 @@
 
  */
 
- @import "foundation_and_overrides"
+ @import "foundation_and_overrides";
+ @import "main_rcc";

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,11 @@
 
   %body
 
-    .grid-container
+    .grid-container.fluid.main
+      .grid-x.grid-padding-x
+        .medium-2.cell.side-nav
+          %h4 side nav
 
-      = yield
+        .medium-10.cell
+
+          = yield

--- a/app/views/properties/_estate_info.html.haml
+++ b/app/views/properties/_estate_info.html.haml
@@ -1,18 +1,70 @@
 - if defined?(@properties) && @properties.present?
-  %h2 Block information
+  %h4
+    Overview for
+    = params[:post_code]
 
-  = @block.address
-  = @block.managerName
-  = @block.managerEmail
-  = @block.managerPhone
-  = @block.floors
-  = @block.entranceDoors
-  = @block.lifts
-  = @block.heating
+  %p.title
+    %strong
+      Block
+  %p
+    = @block.address
 
-  %h2 Estate information
+  %p.title
+    %strong
+      Patch Manager
+  %p
+    %span.list-item
+      = @block.managerName
+    %span.list-item
+      = mail_to @block.managerEmail
+    %span.list-item
+      = link_to @block.managerPhone, "tel:#{@block.managerPhone}"
 
-  = @estate.address
-  = @estate.managerName
-  = @estate.managerEmail
-  = @estate.managerPhone
+  %p.title
+    %strong
+      Block overview
+
+  .grid-x
+    .cell.medium-6
+      %p
+        %span.list-item
+          = @block.floors
+          Floors
+
+        %span.list-item
+          = @block.entranceDoors
+          Entrance Doors
+
+        %span.list-item
+          - unless @block.lifts = 1
+            = @block.lifts
+            Lifts
+
+          - else
+            = @block.lifts
+            Lift
+
+    .cell.medium-6
+      %p
+        %span.list-item
+          = @block.heating
+          Heating
+
+
+  %p.title
+    %strong
+      Estate
+  %p
+    %span.list-item
+      = @estate.address
+
+  %p.title
+    %strong
+      Estate Manager
+  %p
+    %span.list-item
+      = @estate.managerName
+    %span.list-item
+      = mail_to @estate.managerEmail
+    %span.list-item
+      = link_to @estate.managerPhone, "tel:#{@estate.managerPhone}"

--- a/app/views/properties/index.html.haml
+++ b/app/views/properties/index.html.haml
@@ -1,7 +1,7 @@
 .grid-x.grid-padding-x
   .medium-7.cell
-    %h4 Find a property by postcode
     = form_tag properties_path, method: :get do
+      = label_tag 'post_code', 'Find a property by postcode', class: 'h4'
       .input-group
         = text_field_tag :post_code, '', class: 'input-group-field', placeholder: 'Enter postcode...'
         .input-group-button

--- a/app/views/properties/index.html.haml
+++ b/app/views/properties/index.html.haml
@@ -1,17 +1,24 @@
-= form_tag properties_path, method: :get do
-  .grid-x.grid-padding-x
-    .medium-6.cell
-      = label_tag 'post_code', 'Find address by postcode'
+.grid-x.grid-padding-x
+  .medium-7.cell
+    %h4 Find a property by postcode
+    = form_tag properties_path, method: :get do
       .input-group
         = text_field_tag :post_code, '', class: 'input-group-field', placeholder: 'Enter postcode...'
         .input-group-button
           = button_tag 'Find', class: 'button', type: :submit
 
-- if defined?(@properties)
-  - if @properties.present?
-    - @properties.each do |property|
-      = link_to property.address, property_path(property.property_reference)
-  - else
-    %p No properties found
+    - if defined?(@properties)
+      - if @properties.present?
+        %h4
+          List of properties for
+          = params[:post_code]
 
-= render partial: 'estate_info'
+        %ul.list-group
+          - @properties.each do |property|
+            %li.list-group-item
+              = link_to property.address, property_path(property.property_reference)
+      - else
+        %p No properties found
+
+  .medium-5.cell.sidebar
+    = render partial: 'estate_info'

--- a/spec/features/finding_and_viewing_a_property_spec.rb
+++ b/spec/features/finding_and_viewing_a_property_spec.rb
@@ -8,7 +8,7 @@ RSpec.feature 'Admin can find a property and select resident' do
     stub_residents_for_property
     stub_property_find
     visit '/properties/'
-    fill_in 'Find address by postcode', with: 'E5 8TE'
+    fill_in 'Find a property by postcode', with: 'E5 8TE'
     click_on 'Find'
     expect(page).to have_content "1 Estate House"
     expect(page).to have_content "Hackney Block"
@@ -23,7 +23,7 @@ RSpec.feature 'Admin can find a property and select resident' do
   scenario 'with incorrect postcode' do
     stub_property_search([])
     visit '/properties/'
-    fill_in 'Find address by postcode', with: 'E5 8TE'
+    fill_in 'Find a property by postcode', with: 'E5 8TE'
     click_on 'Find'
     expect(page).to have_content "No properties found"
   end
@@ -35,7 +35,7 @@ RSpec.feature 'Admin can find a property and select resident' do
     stub_property_find
     stub_residents_for_property([])
     visit '/properties/'
-    fill_in 'Find address by postcode', with: 'E5 8TE'
+    fill_in 'Find a property by postcode', with: 'E5 8TE'
     click_on 'Find'
     expect(page).to have_content "1 Estate House"
     expect(page).to have_content "Hackney Block"


### PR DESCRIPTION
Added basic styling for the app.

![](https://github.trello.services/images/mini-trello-icon.png)[22-style-list-of-addresses-returned-from-postcode-search-style-sidebar-information-on-block-and-estate-on-search-result-pages](https://trello.com/c/LxEHVVdd/)

<img width="1411" alt="screen shot 2018-06-18 at 17 01 05" src="https://user-images.githubusercontent.com/2632224/41547937-74d4d3da-7319-11e8-8244-2f8c7859c782.png">

