### PR TITLE
Show dwelling metadata on dwelling repairs page

### DIFF
--- a/app/models/dwelling.rb
+++ b/app/models/dwelling.rb
@@ -1,7 +1,8 @@
 class Dwelling
   include ActiveModel::Model
 
-  attr_accessor :propertyReference, :postcode, :address, :maintainable
+  attr_accessor :propertyReference, :postcode, :address, :maintainable,
+                :floor, :residents, :heating, :toilets, :bathrooms
 
   def self.find(dwelling_reference)
     new_from_json(HackneyApi.new.get_property(dwelling_reference))

--- a/app/views/repairs/index.html.haml
+++ b/app/views/repairs/index.html.haml
@@ -1,3 +1,10 @@
+- if @property.floor
+  = "#{@property.floor}#{@property.floor.ordinal} floor"
+= pluralize @property.residents, 'resident'
+= @property.heating
+= pluralize @property.toilets, 'toilet'
+= pluralize @property.bathrooms, 'bathroom'
+
 - @repairs.each do |repair|
   = repair.problemDescription
   = repair.repairRequestReference


### PR DESCRIPTION

Using the metadata revealed here: https://github.com/LBHackney-IT/mock_hackney_api/commit/fd1ce7fd9b9d12c80356410c8a8dec322e0ee087