### PR TITLE
Link repair ID to new repair show page

### DIFF
--- a/app/views/repairs/index.html.haml
+++ b/app/views/repairs/index.html.haml
@@ -7,5 +7,5 @@
 
 - @repairs.each do |repair|
   = repair.problemDescription
-  = repair.repairRequestReference
+  = link_to repair.repairRequestReference, property_repair_path(@property.propertyReference, repair.repairRequestReference)
   = repair.priority


### PR DESCRIPTION
Thought I'd quickly link the repair id on the repair listing page to the repair details view page so we can get to it without hacking URLs :-)