### PR TITLE
feature/34-minimal style for dwelling view and add a repair button

### DIFF
--- a/app/assets/stylesheets/_main_rcc.scss
+++ b/app/assets/stylesheets/_main_rcc.scss
@@ -6,32 +6,133 @@
   $cancelled: #af0000;
   $progress: #778899;
 
+  // #0f3057;
+  // #00587a;
+  // #008891;
+  // #e7e7de;
+
+  $side-nav-bg: #00587a;
+  $side-nav-font: $white;
+
 /*
  * Global styles
  */
 
-.main {
-  padding-top: 2em;
+.rcc-app {
+  margin-top: 2em;
+}
+
+nav.top-bar {
+  border-bottom: 2px solid $dark-gray;
+  color: $white;
+
+  a {
+    color: $white;
+  }
+}
+
+.menu {
+  .menu-text {
+    &.light {
+      font-weight: normal;
+    }
+    &.user-name {
+      padding-right: 0;
+    }
+  }
+
 }
 
 .side-nav {
+  padding-top: $global-padding;
   border-right: 1px solid $medium-gray;
-  height: 100vh;
-  background-color: $light-gray;
+  // height: 100vh;
+  color: $side-nav-font;
+  background-color: $side-nav-bg;
+
+  a {
+    color: $white;
+  }
 }
 
-.sidebar {
+.content {
+  padding-top: $global-padding;
+}
+
+.side-info {
   border-left: 1px solid $medium-gray;
-  height: 100vh;
+  min-height: 100vh;
   background-color: $white;
+  padding-top: $global-padding;
 
   p.title {
     margin-bottom: 0;
   }
 }
 
+
+#sub-nav {
+  border-bottom: 2px solid get-color(secondary);
+
+  .menu {
+    margin: auto 0;
+
+    li {
+      border-top: 1px solid $medium-gray;
+      border-right: 1px solid $medium-gray;
+
+      &.is-active {
+        border-top: 1px solid get-color(secondary);
+      }
+
+      a {
+        display: block;
+      }
+
+      &:hover {
+        background-color: lighten(get-color(secondary), 5%);
+
+        a {
+          color: $white;
+        }
+      }
+    }
+  }
+}
+
+.repairs-list-view {
+  background-color: #e7e7de;
+
+  &.property-summary {
+
+    span {
+      font-size: 0.9rem;
+    }
+  }
+
+  &.repairs-history {
+    padding-top: $global-padding;
+  }
+}
+
 hr.tight {
   margin: 0.5rem auto;
+}
+
+/*
+ * Breadcrumb nav
+ */
+.mini-nav {
+  background-color: lighten(#e7e7de, 7%);
+  border-top: 2px solid $medium-gray;
+  padding-top: $global-padding;
+  padding-left: $global-padding;
+
+  .breadcrumbs {
+    li {
+      font-weight: bold;
+    }
+  }
 }
 
 /*
@@ -69,7 +170,7 @@ hr.tight {
  * Repair details card
  */
 .repair-details-page {
-  background-color: $light-gray;
+  background-color: #e7e7de;
   padding-top: $global-padding;
 }
 /*

--- a/app/assets/stylesheets/_settings.scss
+++ b/app/assets/stylesheets/_settings.scss
@@ -69,8 +69,8 @@ $global-font-size: 100%;
 $global-width: rem-calc(1200);
 $global-lineheight: 1.5;
 $foundation-palette: (
-  primary: #1779ba,
-  secondary: #767676,
+  primary: #00587a,
+  secondary: #008891,
   success: #3adb76,
   warning: #ffae00,
   alert: #cc4b37,
@@ -473,7 +473,7 @@ $menu-nested-margin: $global-menu-nested-margin;
 $menu-items-padding: $global-menu-padding;
 $menu-simple-margin: 1rem;
 $menu-item-color-active: $white;
-$menu-item-background-active: get-color(primary);
+$menu-item-background-active: get-color(secondary);
 $menu-icon-spacing: 0.25rem;
 $menu-item-background-hover: $light-gray;
 $menu-state-back-compat: true;
@@ -846,7 +846,7 @@ $tooltip-radius: $global-radius;
 // -----------
 
 $topbar-padding: 0.5rem;
-$topbar-background: $light-gray;
+$topbar-background: #0f3057;
 $topbar-submenu-background: $topbar-background;
 $topbar-title-spacing: 0.5rem 1rem 0.5rem 0;
 $topbar-input-width: 200px;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
 
     %meta{ :name => "viewport", :content => "width=device-width, initial-scale=1.0" }
 
-    %title= content_for?(:title) ? yield(:title) : "Untitled"
+    %title= content_for?(:title) ? yield(:title) : "RCC"
 
     = stylesheet_link_tag "application"
     -# = javascript_include_tag "vendor/modernizr"
@@ -14,11 +14,27 @@
 
   %body
 
-    .grid-container.fluid.main
+    %nav.top-bar
+      .top-bar-left
+        %ul.menu
+          %li.menu-text.app-title
+            Hackney Repairs Contact Centre
+      .top-bar-right
+        %ul.menu
+          %li.menu-text.light.user-name
+            Lisa Roomian
+          %li
+            =link_to "Log out", ' '
+
+    .grid-container.fluid.rcc-app
       .grid-x.grid-padding-x
         .medium-2.cell.side-nav
-          %h4 side nav
+          %ul.vertical.menu
+            %li.menu-item.is-active
+              =link_to "Find address", '/properties'
+            %li.menu-item
+              =link_to "Find repair", '/properties'
 
-        .medium-10.cell
+        .medium-10.cell.main
 
           = yield

--- a/app/views/properties/index.html.haml
+++ b/app/views/properties/index.html.haml
@@ -1,5 +1,5 @@
 .grid-x.grid-padding-x
-  .medium-7.cell
+  .medium-7.cell.content
     = form_tag properties_path, method: :get do
       = label_tag 'post_code', 'Find a property by postcode', class: 'h4'
       .input-group
@@ -20,6 +20,6 @@
       - else
         %p No properties found
 
-  .medium-5.cell.sidebar
+  .medium-5.cell.side-info
     - if defined?(@properties) && @properties.present?
       = render partial: 'estate_info'

--- a/app/views/properties/show.html.haml
+++ b/app/views/properties/show.html.haml
@@ -1,5 +1,5 @@
 .grid-x.grid-padding-x
-  .medium-7.cell
+  .medium-7.cell.content
     %h2
       = @property.address
       = @property.postcode
@@ -15,6 +15,6 @@
 
     = link_to "The resident is not on the list", property_repairs_path(@property.propertyReference)
 
-  .medium-5.cell.sidebar
+  .medium-5.cell.side-info
     = render partial: 'dwelling_info'
     = render partial: 'estate_info'

--- a/app/views/repairs/index.html.haml
+++ b/app/views/repairs/index.html.haml
@@ -1,11 +1,100 @@
-- if @property.floor
-  = "#{@property.floor}#{@property.floor.ordinal} floor"
-= pluralize @property.residents, 'resident'
-= @property.heating
-= pluralize @property.toilets, 'toilet'
-= pluralize @property.bathrooms, 'bathroom'
+%header
+  .grid-x.grid-margin-x
+    .cell.medium-4
+      %p
+        %strong
+          Property address
+        %span.list-item
+          = @property.address
 
-- @repairs.each do |repair|
-  = repair.problemDescription
-  = link_to repair.repairRequestReference, property_repair_path(@property.propertyReference, repair.repairRequestReference)
-  = repair.priority
+        %span.list-item
+          = @property.postcode
+
+    .cell.medium-8
+      %strong
+        Resident information
+      .grid-x
+        .cell.medium-6
+          %span.list-item
+            John Tenant
+          %span.list-item
+            07556788932
+        .cell.medium-6
+          %span.list-item
+            Cautionary contact
+
+%nav.grid-x.grid-margin-x#sub-nav
+  %ul.cell.menu.expanded
+    %li
+      = link_to "Raise a repair", " "
+    %li.is-active
+      = link_to "Dwelling repairs", " "
+    %li
+      = link_to "Block repairs", " "
+    %li
+      = link_to "Estate repairs", " "
+    %li
+      = link_to "Tenant's Information", " "
+
+.grid-x.grid-margin-x.repairs-list-view.property-summary
+  .cell.medium-8
+    %p
+      %strong
+        Dwelling overview
+    .property-summary
+      - if @property.floor
+        %span
+          = "#{@property.floor}#{@property.floor.ordinal} floor"
+
+      %span
+        = pluralize @property.residents, 'resident'
+      %span
+        = @property.heating
+      %span
+        = pluralize @property.toilets, 'toilet'
+      %span
+        = pluralize @property.bathrooms, 'bathroom'
+
+  .cell.medium-4
+    %br
+    = link_to "Raise a repair for this dwelling", "#" ,:class=>"button"
+
+.grid-x.grid-margin-x.mini-nav
+  .nav
+    .ul.breadcrumbs
+      %li
+        Dwelling repairs history
+
+.grid-x.grid-margin-x.repairs-list-view.repairs-history
+  .cell.medium-8
+
+    - @repairs.each do |repair|
+      .repair.card.status-progress
+        .card-section
+          .grid-x
+            .cell
+              -# repair_req_number
+              %span.leading-number
+                = link_to repair.repairRequestReference, property_repair_path(@property.propertyReference, repair.repairRequestReference)
+              -# Repair priority
+              %span.priority
+                = repair.priority
+              %span.date
+                Created 3 days ago, 20 Jun
+              -# Show each trade from tasks from all WO
+              %span.trade.float-right
+                PLM
+              %hr.tight
+          .grid-x.grid-margin-x
+            .cell
+              %p.repair-description
+                = repair.problemDescription
+            .cell.medium-8
+              -# Repair request status based on completion of tasks in the work order
+              %span.status-text.list-item
+                Tasks awaiting completion
+              -# Summary of status for tasks
+              %span.status-breakdown.list-item
+                1 task in progress, 2 tasks completed
+            .cell.medium-4
+              = link_to "View details", property_repair_path(@property.propertyReference, repair.repairRequestReference)

--- a/app/views/repairs/show.html.haml
+++ b/app/views/repairs/show.html.haml
@@ -1,8 +1,74 @@
-= link_to "Go back to repairs history (dwelling)"
-%h4 Repair details
+%header
+  .grid-x.grid-margin-x
+    .cell.medium-4
+      %p
+        %strong
+          Property address
+        %span.list-item
+          = @property.address
+
+        %span.list-item
+          = @property.postcode
+
+    .cell.medium-8
+      %strong
+        Resident information
+      .grid-x
+        .cell.medium-6
+          %span.list-item
+            John Tenant
+          %span.list-item
+            07556788932
+        .cell.medium-6
+          %span.list-item
+            Cautionary contact
+
+%nav.grid-x.grid-margin-x#sub-nav
+  %ul.cell.menu.expanded
+    %li
+      = link_to "Raise a repair", " "
+    %li.is-active
+      = link_to "Dwelling repairs", " "
+    %li
+      = link_to "Block repairs", " "
+    %li
+      = link_to "Estate repairs", " "
+    %li
+      = link_to "Tenant's Information", " "
+
+.grid-x.grid-margin-x.repairs-list-view.property-summary
+  .cell.medium-8
+    %p
+      %strong
+        Dwelling overview
+    .property-summary
+      - if @property.floor
+        %span
+          = "#{@property.floor}#{@property.floor.ordinal} floor"
+
+      %span
+        = pluralize @property.residents, 'resident'
+      %span
+        = @property.heating
+      %span
+        = pluralize @property.toilets, 'toilet'
+      %span
+        = pluralize @property.bathrooms, 'bathroom'
+
+  .cell.medium-4
+    %br
+    = link_to "Raise a repair for this dwelling", "#" ,:class=>"button"
+
+.grid-x.grid-padding-x.mini-nav
+  .nav
+    .ul.breadcrumbs
+      %li
+        = link_to "Dwelling repairs history"
+      %li
+        Repair details (4390916)
+
 .grid-x.grid-padding-x.repair-details-page
   .cell
-
     -# Repair request card
     %h6
       Repair request


### PR DESCRIPTION
### 1 Improve overall app navigation 
Added top bar with app title.
Moved main tasks to the left sidebar.

### 2 Build and style repair history page, improve repair detail view

Dwelling repair history has an improved layout and design.
Added bradcrumb mini navigation to help user navigate between repair history and repair details.

Added basic colour styling to differentiate certain parts of the application
- top bar
- left-side navigation
- main content
- dwelling / block / estate view navigation

Added "Raise a repair for this dwelling button" and a "Raise a repair" navigation element, that would be holding a space for rise a repair user task.

#### TODO:
 - different reusable parts should be extracted to seperate partials like:
 -- address search result top overview, navigations (tabs), dwelling overview,
  -- repairs list view
- all styles are in one file for 'rapid styling' before testing with users. Ideally the styles should be split into separate components where possible and 'views'.
- add missing links in breadcrumb navigation

### 3 Screens
![dwelling_repairs_history](https://user-images.githubusercontent.com/2632224/41906178-1ddf7586-7935-11e8-85bb-a3a10e5f8015.png)
![repair_details](https://user-images.githubusercontent.com/2632224/41906179-1df723a2-7935-11e8-8d03-48d988ff9abf.png)


